### PR TITLE
Fix for removal of empty methods

### DIFF
--- a/src/main/java/org/walkmod/sonar/visitors/RemoveEmptyMethod.java
+++ b/src/main/java/org/walkmod/sonar/visitors/RemoveEmptyMethod.java
@@ -20,15 +20,14 @@
 
 package org.walkmod.sonar.visitors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import org.walkmod.javalang.ast.body.BodyDeclaration;
 import org.walkmod.javalang.ast.body.ClassOrInterfaceDeclaration;
 import org.walkmod.javalang.ast.body.MethodDeclaration;
 import org.walkmod.javalang.ast.body.ModifierSet;
 import org.walkmod.javalang.ast.stmt.BlockStmt;
+import org.walkmod.javalang.compiler.symbols.RequiresSemanticAnalysis;
 import org.walkmod.javalang.visitors.VoidVisitorAdapter;
 import org.walkmod.walkers.VisitorContext;
 
@@ -38,109 +37,8 @@ import org.walkmod.walkers.VisitorContext;
  * @author mohanasundar.n
  *
  */
+@RequiresSemanticAnalysis
 public class RemoveEmptyMethod extends VoidVisitorAdapter<VisitorContext> {
-
-	/** The remove default. */
-	private boolean removeDefault;
-
-	/** The remove public. */
-	private boolean removePublic;
-
-	/** The remove private. */
-	private boolean removePrivate = true;
-
-	/** The remove protected. */
-	private boolean removeProtected;
-
-	/**
-	 * Sets the method.
-	 *
-	 * @param method
-	 *            the new method
-	 */
-	public void setMethod(String method) {
-		List<String> list = new ArrayList<String>(Arrays.asList(method.split(",")));
-		setRemoveDefault(list.remove("default"));
-		setRemovePublic(list.remove("public"));
-		setRemovePrivate(list.remove("private"));
-		setRemoveProtected(list.remove("protected"));
-	}
-
-	/**
-	 * Checks if is removes the default.
-	 *
-	 * @return true, if is removes the default
-	 */
-	public boolean isRemoveDefault() {
-		return removeDefault;
-	}
-
-	/**
-	 * Sets the removes the default.
-	 *
-	 * @param removeDefault
-	 *            the new removes the default
-	 */
-	public void setRemoveDefault(boolean removeDefault) {
-		this.removeDefault = removeDefault;
-	}
-
-	/**
-	 * Checks if is removes the public.
-	 *
-	 * @return true, if is removes the public
-	 */
-	public boolean isRemovePublic() {
-		return removePublic;
-	}
-
-	/**
-	 * Sets the removes the public.
-	 *
-	 * @param removePublic
-	 *            the new removes the public
-	 */
-	public void setRemovePublic(boolean removePublic) {
-		this.removePublic = removePublic;
-	}
-
-	/**
-	 * Checks if is removes the private.
-	 *
-	 * @return true, if is removes the private
-	 */
-	public boolean isRemovePrivate() {
-		return removePrivate;
-	}
-
-	/**
-	 * Sets the removes the private.
-	 *
-	 * @param removePrivate
-	 *            the new removes the private
-	 */
-	public void setRemovePrivate(boolean removePrivate) {
-		this.removePrivate = removePrivate;
-	}
-
-	/**
-	 * Checks if is removes the protected.
-	 *
-	 * @return true, if is removes the protected
-	 */
-	public boolean isRemoveProtected() {
-		return removeProtected;
-	}
-
-	/**
-	 * Sets the removes the protected.
-	 *
-	 * @param removeProtected
-	 *            the new removes the protected
-	 */
-	public void setRemoveProtected(boolean removeProtected) {
-		this.removeProtected = removeProtected;
-	}
 
 	/*
 	 * (non-Javadoc)
@@ -151,47 +49,36 @@ public class RemoveEmptyMethod extends VoidVisitorAdapter<VisitorContext> {
 	 */
 	@Override
 	public void visit(ClassOrInterfaceDeclaration n, VisitorContext arg) {
+		List<BodyDeclaration> result = new LinkedList<BodyDeclaration>();
+
 		List<BodyDeclaration> members = n.getMembers();
-		for (int i = 0; i < members.size();) {
-			BodyDeclaration bodyDeclaration = members.get(i);
+		Iterator<BodyDeclaration> it = members.iterator();
+		while(it.hasNext()) {
+			BodyDeclaration bodyDeclaration = it.next();
+			boolean remove = false;
+
 			if (bodyDeclaration instanceof MethodDeclaration) {
 				MethodDeclaration methodDeclaration = ((MethodDeclaration) bodyDeclaration);
 				int modifiers = methodDeclaration.getModifiers();
-				boolean isPublic = ModifierSet.isPublic(modifiers);
-				if (isPublic) {
-					if (!isRemovePublic()) {
-						i++;
-						continue;
-					}
-				}
-				boolean isPrivate = ModifierSet.isPrivate(modifiers);
-				if (isPrivate) {
-					if (!isRemovePrivate()) {
-						i++;
-						continue;
-					}
-				}
-				boolean isProtected = ModifierSet.isProtected(modifiers);
-				if (isProtected) {
-					if (!isRemoveProtected()) {
-						i++;
-						continue;
-					}
-				}
-				if (!isPublic && !isPrivate && !isProtected) {
-					if (!isRemoveDefault()) {
-						i++;
-						continue;
-					}
-				}
-				BlockStmt body = methodDeclaration.getBody();
-				if (body != null && body.getStmts() == null) {
-					members.remove(i);
-					continue;
-				}
+
+				remove = ModifierSet.isPrivate(modifiers)
+						&& !hasStatements(methodDeclaration)
+						&& isUnused(methodDeclaration);
 			}
-			i++;
+			if(!remove) {
+				result.add(bodyDeclaration);
+			}
 		}
+		n.setMembers(result);
 		super.visit(n, arg);
+	}
+
+	private boolean hasStatements(MethodDeclaration md) {
+		BlockStmt body = md.getBody();
+		return body != null && body.getStmts()!= null && !body.getStmts().isEmpty();
+	}
+
+	private boolean isUnused(MethodDeclaration md) {
+		return md.getUsages() == null || md.getUsages().isEmpty();
 	}
 }

--- a/src/test/java/org/walkmod/sonar/visitors/RemoveEmptyMethodTest.java
+++ b/src/test/java/org/walkmod/sonar/visitors/RemoveEmptyMethodTest.java
@@ -1,0 +1,26 @@
+package org.walkmod.sonar.visitors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.walkmod.javalang.ast.CompilationUnit;
+import org.walkmod.javalang.test.SemanticTest;
+
+
+public class RemoveEmptyMethodTest extends SemanticTest {
+
+   @Test
+   public void testRemoval() throws Exception{
+      CompilationUnit cu = compile("public class Foo{ private void bar() {} }");
+      RemoveEmptyMethod visitor = new RemoveEmptyMethod();
+      cu.accept(visitor, null);
+      Assert.assertTrue(cu.getTypes().get(0).getMembers().isEmpty());
+   }
+   
+   @Test
+   public void testIsNotRemoved() throws Exception{
+      CompilationUnit cu = compile("public class Foo{ private void bar() {} private void test() {bar();} }");
+      RemoveEmptyMethod visitor = new RemoveEmptyMethod();
+      cu.accept(visitor, null);
+      Assert.assertEquals(2, cu.getTypes().get(0).getMembers().size());
+   }
+}


### PR DESCRIPTION
This patch deletes configurations to remove non-private methods
and also checks if they are used before deleting. If they are
not used, then, they are deleted.