### PR TITLE
CollapsibleIfStatements fix for node positions

### DIFF
--- a/src/main/java/org/walkmod/sonar/visitors/CollapsibleIfStatements.java
+++ b/src/main/java/org/walkmod/sonar/visitors/CollapsibleIfStatements.java
@@ -46,14 +46,14 @@ public class CollapsibleIfStatements extends  VoidVisitorAdapter<VisitorContext>
                Statement thisElseStmt = n.getElseStmt();
                if (thisElseStmt == null) {
                   try{
-                  Expression rightExpression = parentIf.getCondition();
+                  Expression rightExpression = parentIf.getCondition().clone();
                   if (rightExpression instanceof BinaryExpr) {
-                     rightExpression = new EnclosedExpr(parentIf.getCondition().clone());
+                     rightExpression = new EnclosedExpr(rightExpression);
                   }
 
-                  Expression leftExpression = n.getCondition();
+                  Expression leftExpression = n.getCondition().clone();
                   if (leftExpression instanceof BinaryExpr) {
-                     leftExpression = new EnclosedExpr(n.getCondition().clone());
+                     leftExpression = new EnclosedExpr(leftExpression);
                   }
 
                   BinaryExpr condition = new BinaryExpr(rightExpression, leftExpression, BinaryExpr.Operator.and);

--- a/src/test/java/org/walkmod/sonar/visitors/CollapsibleIfStatementsTest.java
+++ b/src/test/java/org/walkmod/sonar/visitors/CollapsibleIfStatementsTest.java
@@ -25,6 +25,28 @@ public class CollapsibleIfStatementsTest {
       Assert.assertNull(stmt.getStmts());
       Assert.assertTrue(ifStmt.getCondition() instanceof BinaryExpr);
    }
+
+   @Test
+   public void testGeneratesConditionsWithNewNodes() throws Exception {
+      String code = "public class Foo {\n" +
+              "public void bar(String name, String other) {\n" +
+              "  if (name.equals(other)) {\n" +
+              "    if (other.equals(name)) {\n" +
+              "      System.out.println(name);\n" +
+              "    }\n" +
+              "  }\n" +
+              "}\n" +
+              "}";
+      CollapsibleIfStatements visitor = new CollapsibleIfStatements();
+      CompilationUnit cu = ASTManager.parse(code);
+      visitor.visit(cu, null);
+      MethodDeclaration md = (MethodDeclaration) cu.getTypes().get(0).getMembers().get(0);
+      BlockStmt block = md.getBody();
+      IfStmt ifStmt = (IfStmt) block.getStmts().get(0);
+      BinaryExpr expr = (BinaryExpr) ifStmt.getCondition();
+      Assert.assertTrue(expr.getLeft().isNewNode());
+      Assert.assertTrue(expr.getRight().isNewNode());
+   }
    
    @Test
    public void test2() throws Exception{


### PR DESCRIPTION
This patches fixes that nodes of the new condition are
regenerated with new positions to avoid writing actions
conflicts with the removal of the nested ifs.