### PR TITLE
Update LocalVarsShouldComplyWithNamingConvention.java

### DIFF
--- a/src/main/java/org/walkmod/sonar/visitors/LocalVarsShouldComplyWithNamingConvention.java
+++ b/src/main/java/org/walkmod/sonar/visitors/LocalVarsShouldComplyWithNamingConvention.java
@@ -55,8 +55,7 @@ public class LocalVarsShouldComplyWithNamingConvention extends VoidVisitorAdapte
       String result = "";
       boolean toUpperCase = false;
       for (int i = 0; i < letters.length; i++) {
-         if (letters[i] == '$' || letters[i] == '_') {
-            i++;
+         if (letters[i] == '$' || letters[i] == '_') {            
             toUpperCase = true;
          } else {
             if (toUpperCase) {


### PR DESCRIPTION
Removal of i++ as by default it should pickup the char next to '\_' and convert it uppercase. But with i++ it skips the given char next to '_' and treats the 2nd next char in uppercase concatenation. 
eg: 'employee_code' is getting converted to employeeOde instead of employeeCode.